### PR TITLE
プレイヤー作成時にトランザクション機能を追加した

### DIFF
--- a/components/Form/CreatePlayerForm.vue
+++ b/components/Form/CreatePlayerForm.vue
@@ -101,10 +101,16 @@ export default {
   },
   methods: {
     addPlayerToDatabase(playerName) {
-      if (playerName !== '') {
-        this.$fire.database.ref('players/' + playerName).set(this.player)
-        alert('送信が成功しました')
-      }
+      const playerRef = this.$fire.database.ref('players/' + playerName)
+
+      playerRef.transaction((currentData) => {
+        if (playerName !== '' && currentData === null) {
+          playerRef.set(this.player)
+          alert('送信が成功しました')
+        } else {
+          alert('値を確認してください。送信が失敗しました')
+        }
+      })
     },
   },
 }


### PR DESCRIPTION
## 何をしたいか
プレイヤー作成時に名前が被るとデータが上書きされてしまうので、トランザクションを追加してデータが上書きされないようにしたい

fixed #2

## テストケース
- [x] 既に登録してあるプレイヤーと名前が同一であった場合、警告なしにデータが上書きされないか